### PR TITLE
Fixed setup.py from crashing when installing first time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 import os
+import re
 from setuptools import setup, find_packages
-from dalmatian.__about__ import __version__
+with open("dalmatian/__about__.py") as reader:
+    __version__ = re.search(
+        r'__version__ ?= ?[\'\"]([\w.]+)[\'\"]',
+        reader.read()
+    ).group(1)
 _README           = os.path.join(os.path.dirname(__file__), 'README.md')
 _LONG_DESCRIPTION = open(_README).read()
 


### PR DESCRIPTION
Previously, if any prereqs were missing at install time, install failed because setup.py imports dalmatian (which can't be imported because prereqs haven't been installed