### PR TITLE
Removed status_code assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,105 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/dalmatian/core.py
+++ b/dalmatian/core.py
@@ -15,7 +15,7 @@ from .__about__ import __version__
 
 # Collection of high-level wrapper functions for FireCloud API
 
-class FirecloudError(ValueError):
+class FirecloudError(AssertionError):
     pass
 
 def check_response_status(response, code):
@@ -39,6 +39,8 @@ def check_response_status(response, code):
                 response.text.strip()
             )
         )
+    #for chaining
+    return response
 
 #------------------------------------------------------------------------------
 #  Helper functions for processing timestamps

--- a/dalmatian/core.py
+++ b/dalmatian/core.py
@@ -381,11 +381,8 @@ def update_method(namespace, method, synopsis, wdl_file, public=False, delete_ol
 
     # push new version
     r = firecloud.api.update_repository_method(namespace, method, synopsis, wdl_file)
-    if r.status_code==201:
-        print("Successfully pushed {}/{}. New SnapshotID: {}".format(namespace, method, r.json()['snapshotId']))
-    else:
-        print(r.text)
-        raise ValueError('Update failed.')
+    check_response_status(r,201)
+    print("Successfully pushed {}/{}. New SnapshotID: {}".format(namespace, method, r.json()['snapshotId']))
 
     if public:
         print('  * setting public read access.')

--- a/dalmatian/core.py
+++ b/dalmatian/core.py
@@ -381,8 +381,11 @@ def update_method(namespace, method, synopsis, wdl_file, public=False, delete_ol
 
     # push new version
     r = firecloud.api.update_repository_method(namespace, method, synopsis, wdl_file)
-    check_response_status(r,201)
-    print("Successfully pushed {}/{}. New SnapshotID: {}".format(namespace, method, r.json()['snapshotId']))
+    try:
+        check_response_status(r,201)
+        print("Successfully pushed {}/{}. New SnapshotID: {}".format(namespace, method, r.json()['snapshotId']))
+    except FirecloudError as e:
+        raise ValueError("Update failed.") from e
 
     if public:
         print('  * setting public read access.')

--- a/dalmatian/wmanager.py
+++ b/dalmatian/wmanager.py
@@ -1142,8 +1142,6 @@ class WorkspaceManager(object):
         check_response_status(r,204)
         if isinstance(attrs, pd.DataFrame):
             print("Successfully updated attributes '{}' for {} {}s.".format(attrs.columns.tolist(), attrs.shape[0], etype))
-        elif isinstance(attrs, pd.Series):
-            print("Successfully updated attribute '{}' for {} {}s.".format(attrs.name, len(attrs), etype))
         else:
             print("Successfully updated attribute '{}' for {} {}s.".format(attrs.name, len(attrs), etype))
         # except:  # revert to public API

--- a/dalmatian/wmanager.py
+++ b/dalmatian/wmanager.py
@@ -142,7 +142,7 @@ class WorkspaceManager(object):
     def get_bucket_id(self):
         """Get the GCS bucket ID associated with the workspace"""
         r = firecloud.api.get_workspace(self.namespace, self.workspace)
-        assert r.status_code==200
+        check_response_status(r,200)
         r = r.json()
         bucket_id = r['workspace']['bucketName']
         return bucket_id
@@ -240,7 +240,7 @@ class WorkspaceManager(object):
             }
             attrs = [firecloud.api._attr_set(i,j) for i,j in attr_dict.items()]
             r = firecloud.api.update_entity(self.namespace, self.workspace, 'participant', k, attrs)
-            assert r.status_code==200
+            check_response_status(r,200)
         print('\n    Finished attaching {}s to {} participants'.format(etype, len(participant_ids)))
 
 
@@ -318,14 +318,14 @@ class WorkspaceManager(object):
         # attrs must be list:
         attrs = [firecloud.api._attr_set(i,j) for i,j in attr_dict.items()]
         r = firecloud.api.update_workspace_attributes(self.namespace, self.workspace, attrs)
-        assert r.status_code==200
+        check_response_status(r,200)
         print('Successfully updated workspace attributes in {}/{}'.format(self.namespace, self.workspace))
 
 
     def get_attributes(self):
         """Get workspace attributes"""
         r = firecloud.api.get_workspace(self.namespace, self.workspace)
-        assert r.status_code==200
+        check_response_status(r,200)
         attr = r.json()['workspace']['attributes']
         for k in [k for k in attr if 'library:' in k]:
             attr.pop(k)
@@ -377,21 +377,21 @@ class WorkspaceManager(object):
         """Get metadata JSON for a specific workflow"""
         metadata = firecloud.api.get_workflow_metadata(self.namespace, self.workspace,
             submission_id, workflow_id)
-        assert metadata.status_code==200
+        check_response_status(metadata,200)
         return metadata.json()
 
 
     def get_submission(self, submission_id):
         """Get submission metadata"""
         r = firecloud.api.get_submission(self.namespace, self.workspace, submission_id)
-        assert r.status_code==200
+        check_response_status(r,200)
         return r.json()
 
 
     def list_submissions(self, config=None):
         """List all submissions from workspace"""
         submissions = firecloud.api.list_submissions(self.namespace, self.workspace)
-        assert submissions.status_code==200
+        check_response_status(submissions,200)
         submissions = submissions.json()
 
         if config is not None:
@@ -403,7 +403,7 @@ class WorkspaceManager(object):
     def list_configs(self):
         """List configurations in workspace"""
         r = firecloud.api.list_workspace_configs(self.namespace, self.workspace)
-        assert r.status_code==200
+        check_response_status(r,200)
         return r.json()
 
 
@@ -489,7 +489,7 @@ class WorkspaceManager(object):
 
         # get list of expected outputs
         r = firecloud.api.get_workspace_config(self.namespace, self.workspace, cnamespace, configuration)
-        assert r.status_code==200
+        check_response_status(r,200)
         r = r.json()
         output_map = {i.split('.')[-1]:j.split('this.')[-1] for i,j in r['outputs'].items()}
         columns = list(output_map.values())
@@ -767,7 +767,7 @@ class WorkspaceManager(object):
         # copy config to repo
         r = firecloud.api.copy_config_to_repo(self.namespace, self.workspace,
                 from_cnamespace, from_config, to_cnamespace, to_config)
-        assert r.status_code==200
+        check_response_status(r,200)
         print("Successfully copied {}/{}. New SnapshotID: {}".format(to_cnamespace, to_config, r.json()['snapshotId']))
 
         # make configuration public
@@ -779,7 +779,7 @@ class WorkspaceManager(object):
         # delete old version
         if old_version is not None:
             r = firecloud.api.delete_repository_config(to_cnamespace, to_config, old_version)
-            assert r.status_code==200
+            check_response_status(r,200)
             print("Successfully deleted SnapshotID {}.".format(old_version))
 
 
@@ -1005,7 +1005,7 @@ class WorkspaceManager(object):
         #     elif isinstance(attrs, Iterable):
         #         rm_list = [{"op": "RemoveAttribute", "attributeName": i} for i in attrs]
         #     r = firecloud.api.update_entity(self.namespace, self.workspace, etype, ename, rm_list)
-        #         assert r.status_code==200
+        #         check_response_status(r,200)
 
 
     def delete_sample_attributes(self, attrs, entity_id=None, delete_files=False, dry_run=False):
@@ -1075,7 +1075,7 @@ class WorkspaceManager(object):
 
 
     #-------------------------------------------------------------------------
-    #  
+    #
     #-------------------------------------------------------------------------
     def find_sample_set(self, sample_id, sample_set_df=None):
         """Find sample set(s) containing sample"""

--- a/dalmatian/wmanager.py
+++ b/dalmatian/wmanager.py
@@ -114,29 +114,22 @@ class WorkspaceManager(object):
         """Create the workspace, or clone from another"""
         if wm is None:
             r = firecloud.api.create_workspace(self.namespace, self.workspace)
-            if r.status_code==201:
-                print('Workspace {}/{} successfully created.'.format(self.namespace, self.workspace))
-            elif r.status_code==409:
-                print(r.json()['message'])
-            else:
-                print(r.text)
+            check_response_status(r,201)
+            print('Workspace {}/{} successfully created.'.format(self.namespace, self.workspace))
         else:  # clone workspace
             r = firecloud.api.clone_workspace(wm.namespace, wm.workspace, self.namespace, self.workspace)
-            if r.status_code==201:
-                print('Workspace {}/{} successfully cloned from {}/{}.'.format(
-                    self.namespace, self.workspace, wm.namespace, wm.workspace))
-            else:
-                print(r.text)
+            check_response_status(r,201)
+            print('Workspace {}/{} successfully cloned from {}/{}.'.format(
+                self.namespace, self.workspace, wm.namespace, wm.workspace)
+            )
 
 
     def delete_workspace(self):
         """Delete the workspace"""
         r = firecloud.api.delete_workspace(self.namespace, self.workspace)
-        if r.status_code==202:
-            print('Workspace {}/{} successfully deleted.'.format(self.namespace, self.workspace))
-            print('  * '+r.json()['message'])
-        else:
-            print(r.text)
+        check_response_status(r,202)
+        print('Workspace {}/{} successfully deleted.'.format(self.namespace, self.workspace))
+        print('  * '+r.json()['message'])
 
 
     def get_bucket_id(self):
@@ -155,7 +148,8 @@ class WorkspaceManager(object):
         s = firecloud.api.upload_entities(self.namespace, self.workspace, buf.getvalue())
         buf.close()
         et = etype.replace('_set', ' set')
-        if s.status_code==200:
+        try:
+            check_response_status(s,200)
             if 'set' in etype:
                 if index:
                     sets = df.index
@@ -166,9 +160,8 @@ class WorkspaceManager(object):
                     print('  * {} ({} {}s)'.format(s, np.sum(sets==s), et.replace(' set','')))
             else:
                 print('Successfully imported {} {}s.'.format(df.shape[0], et))
-        else:
-            print(s.text)
-            raise ValueError('{} import failed.'.format(et.capitalize()))
+        except FirecloudError as e
+            raise ValueError('{} import failed.'.format(et.capitalize())) from e
 
 
     def upload_participants(self, participant_ids):
@@ -792,10 +785,8 @@ class WorkspaceManager(object):
         c = c[np.argmax([i['snapshotId'] for i in c])]
         r = firecloud.api.copy_config_from_repo(self.namespace, self.workspace,
             cnamespace, cname, c['snapshotId'], cnamespace, cname)
-        if r.status_code==201:
-            print('Successfully imported configuration "{}/{}" (SnapshotId {})'.format(cnamespace, cname, c['snapshotId']))
-        else:
-            print(r.text)
+        check_response_status(r,201)
+        print('Successfully imported configuration "{}/{}" (SnapshotId {})'.format(cnamespace, cname, c['snapshotId']))
 
 
     #-------------------------------------------------------------------------
@@ -805,10 +796,8 @@ class WorkspaceManager(object):
         """Wrapper for firecloud.api.get_entities_query"""
         r = firecloud.api.get_entities_query(self.namespace, self.workspace,
                 etype, page=page, page_size=page_size)
-        if r.status_code==200:
-            return r.json()
-        else:
-            print(r.text)
+        check_response_status(r,200)
+        return r.json()
 
 
     def get_entities(self, etype, page_size=1000):
@@ -882,11 +871,10 @@ class WorkspaceManager(object):
                 'op': 'AddUpdateAttribute'
             }]
             r = firecloud.api.update_entity(self.namespace, self.workspace, etype+'_set', set_id, attrs)
-            if r.status_code==200:
-                print('{} set "{}" ({} {}s) successfully updated.'.format(
-                    etype.capitalize(), set_id, len(entity_ids), etype))
-            else:
-                print(r.text)
+            check_response_status(r,200)
+            print('{} set "{}" ({} {}s) successfully updated.'.format(
+                etype.capitalize(), set_id, len(entity_ids), etype)
+            )
         else:
             set_df = pd.DataFrame(
                 data=np.c_[[set_id]*len(entity_ids), entity_ids],
@@ -931,10 +919,8 @@ class WorkspaceManager(object):
         }
         attrs = [firecloud.api._attr_set(i,j) for i,j in attr_dict.items()]
         r = firecloud.api.update_entity(self.namespace, self.workspace, 'sample_set', super_set_id, attrs)
-        if r.status_code==200:
-            print('Set of sample sets "{}" successfully created.'.format(super_set_id))
-        else:
-            print(r.text)
+        check_response_status(r,200)
+        print('Set of sample sets "{}" successfully created.'.format(super_set_id))
 
 
     #-------------------------------------------------------------------------
@@ -995,10 +981,8 @@ class WorkspaceManager(object):
 
         # TODO: try
         r = _batch_update_entities(self.namespace, self.workspace, attr_list)
-        if r.status_code==204:
-            print(msg)
-        else:
-            print(r.text)
+        check_response_status(r,204)
+        print(msg)
         # except:  # rawls API not available
         #     if isinstance(attrs, str):
         #         rm_list = [{"op": "RemoveAttribute", "attributeName": attrs}]
@@ -1029,10 +1013,8 @@ class WorkspaceManager(object):
     def delete_entity(self, etype, entity_ids):
         """Delete entity or list of entities"""
         r = firecloud.api.delete_entity_type(self.namespace, self.workspace, etype, entity_ids)
-        if r.status_code==204:
-            print('{}(s) {} successfully deleted.'.format(etype.replace('_set', ' set').capitalize(), entity_ids))
-        else:
-            print(r.text)
+        check_response_status(r,204)
+        print('{}(s) {} successfully deleted.'.format(etype.replace('_set', ' set').capitalize(), entity_ids))
 
 
     def delete_sample(self, sample_ids):
@@ -1053,10 +1035,8 @@ class WorkspaceManager(object):
         elif r.status_code==409:
             if delete_dependencies:
                 r2 = firecloud.api.delete_entities(self.namespace, self.workspace, r.json())
-                if r2.status_code==204:
-                    print('Participant(s) {} and dependent entities successfully deleted.'.format(participant_ids))
-                else:
-                    print(r2.text)
+                check_response_status(r2,204)
+                print('Participant(s) {} and dependent entities successfully deleted.'.format(participant_ids))
             else:
                 print('The following entities must be deleted before the participant(s) can be deleted:')
                 print(r.text)
@@ -1159,15 +1139,13 @@ class WorkspaceManager(object):
         # try rawls batch call if available
         r = _batch_update_entities(self.namespace, self.workspace, attr_list)
         # try:  # TODO
-        if r.status_code==204:
-            if isinstance(attrs, pd.DataFrame):
-                print("Successfully updated attributes '{}' for {} {}s.".format(attrs.columns.tolist(), attrs.shape[0], etype))
-            elif isinstance(attrs, pd.Series):
-                print("Successfully updated attribute '{}' for {} {}s.".format(attrs.name, len(attrs), etype))
-            else:
-                print("Successfully updated attribute '{}' for {} {}s.".format(attrs.name, len(attrs), etype))
+        check_response_status(r,204)
+        if isinstance(attrs, pd.DataFrame):
+            print("Successfully updated attributes '{}' for {} {}s.".format(attrs.columns.tolist(), attrs.shape[0], etype))
+        elif isinstance(attrs, pd.Series):
+            print("Successfully updated attribute '{}' for {} {}s.".format(attrs.name, len(attrs), etype))
         else:
-            print(r.text)
+            print("Successfully updated attribute '{}' for {} {}s.".format(attrs.name, len(attrs), etype))
         # except:  # revert to public API
         #     attrs = [firecloud.api._attr_set(i,j) for i,j in attr_dict.items()]
         #     r = firecloud.api.update_entity(self.namespace, self.workspace, etype, ename, attrs)
@@ -1198,16 +1176,12 @@ class WorkspaceManager(object):
         if json_body['name'] not in [m['name'] for m in configs]:
             # configuration doesn't exist -> name, namespace specified in json_body
             r = firecloud.api.create_workspace_config(self.namespace, self.workspace, json_body)
-            if r.status_code==201:
-                print('Successfully added configuration: {}'.format(json_body['name']))
-            else:
-                print(r.text)
+            check_response_status(r,201)
+            print('Successfully added configuration: {}'.format(json_body['name']))
         else:
             r = firecloud.api.update_workspace_config(self.namespace, self.workspace, json_body['namespace'], json_body['name'], json_body)
-            if r.status_code==200:
-                print('Successfully updated configuration: {}'.format(json_body['name']))
-            else:
-                print(r.text)
+            check_response_status(r,200)
+            print('Successfully updated configuration: {}'.format(json_body['name']))
 
 
     def check_configuration(self, config_name):
@@ -1241,7 +1215,5 @@ class WorkspaceManager(object):
         """Create submission"""
         r = firecloud.api.create_submission(self.namespace, self.workspace,
             cnamespace, config, entity, etype, expression=expression, use_callcache=use_callcache)
-        if r.status_code==201:
-            print('Successfully created submission {}.'.format(r.json()['submissionId']))
-        else:
-            print(r.text)
+        check_response_status(r,201)
+        print('Successfully created submission {}.'.format(r.json()['submissionId']))


### PR DESCRIPTION
Anywhere where `assert response.status_code==n` is used, I've replaced it with a new function `check_response_status` which achieves the same result, but with two changes:
1) It now raises a `dalmatian.FirecloudError` which is derived from `AssertionError`, so code handling AssertionErrors will still run
2) The error text on the FirecloudError is standardized to include the status code and the error text from firecloud (if any)

Additionally, there were many points in the code which manually check `if response.status_code==n` and print the response text on failure. I've also replaced these instances with `check_response_status` so that an exception is raised (a stronger indication of failure than printing text to stdout) and the error text is also standardized by check_response_status


Lastly, I've added the github standard [gitignore for python](https://github.com/github/gitignore/blob/master/Python.gitignore)