### PR TITLE
Update wm.display_status() to not throw warning when getting status for a single entity

### DIFF
--- a/dalmatian/wmanager.py
+++ b/dalmatian/wmanager.py
@@ -589,7 +589,7 @@ class WorkspaceManager(object):
             state_df.loc[i] = [metadata['calls'][t][-1]['executionStatus'] if t in metadata['calls'] else 'Waiting' for t in workflow_tasks]
         print()
         state_df.rename(columns={i:i.split('.')[1] for i in state_df.columns}, inplace=True)
-        summary_df = pd.concat([state_df[c].value_counts() for c in state_df], axis=1).fillna(0).astype(int)
+        summary_df = state_df.apply(lambda x : x.value_counts(), axis = 0).fillna(0).astype(int)
         print(summary_df)
         state_df[['workflow_id', 'submission_id']] = status_df.loc[ix, ['workflow_id', 'submission_id']]
 


### PR DESCRIPTION
pd.concat() throws non-concatenation axis alignment warning when concatenating
dataframes that each comprise a single row and column, as is the case when
running WorkspaceManager.display_status() when only a single entity is being run:

```
wmanager.py:597: FutureWarning: Sorting because non-concatenation axis is not aligned. A future version
of pandas will change to not sort by default.

To accept the future behavior, pass 'sort=False'.

To retain the current behavior and silence the warning, pass 'sort=True'.
```

Plus, df.apply() is cleaner than a list comprehension over all the columns :-)