### PR TITLE
Clarify iterator

### DIFF
--- a/dalmatian/wmanager.py
+++ b/dalmatian/wmanager.py
@@ -2004,9 +2004,9 @@ class WorkspaceManager(object):
 
         if isinstance(attrs, pd.DataFrame):
             attr_list = []
-            for i,row in attrs.iterrows():
+            for entity, row in attrs.iterrows():
                 attr_list.extend([{
-                    'name':row.name,
+                    'name':entity,
                     'entityType':etype,
                     'operations': [
                         {


### PR DESCRIPTION
* Avoids reusing variable name `i`
* Avoids redundantly referencing `row.name` (this is the first value in the tuple returned by `iterrows`, which previously went unused)