### PR TITLE
Add dry run to make_pairs

### DIFF
--- a/dalmatian/wmanager.py
+++ b/dalmatian/wmanager.py
@@ -500,10 +500,11 @@ class WorkspaceManager(object):
         self.update_participant_entities('pair')
 
 
-    def make_pairs(self, sample_set_id=None):
+    def make_pairs(self, sample_set_id=None, dry=False):
         """
         Make all possible pairs from participants (all or a specified set)
         Requires sample_type sample level annotation 'Normal' or 'Tumor'
+        If dry == True, simply return the dataframe of pairs that would be uploaded.
         """
         # get data from sample set or all samples
         if sample_set_id is None:
@@ -534,7 +535,11 @@ class WorkspaceManager(object):
             index=pair_ids
         )
         pair_df.index.name = 'entity:pair_id'
-        self.upload_entities('pair', pair_df)
+
+        if not dry:
+            self.upload_entities('pair', pair_df)
+        else:
+            return pair_df
 
 
     def update_sample_attributes(self, attrs, sample_id=None):

--- a/dalmatian/wmanager.py
+++ b/dalmatian/wmanager.py
@@ -500,11 +500,11 @@ class WorkspaceManager(object):
         self.update_participant_entities('pair')
 
 
-    def make_pairs(self, sample_set_id=None, dry=False):
+    def make_pairs(self, sample_set_id=None, dry_run=False):
         """
         Make all possible pairs from participants (all or a specified set)
         Requires sample_type sample level annotation 'Normal' or 'Tumor'
-        If dry == True, simply return the dataframe of pairs that would be uploaded.
+        If dry_run == True, simply return the dataframe of pairs that would be uploaded.
         """
         # get data from sample set or all samples
         if sample_set_id is None:
@@ -536,7 +536,7 @@ class WorkspaceManager(object):
         )
         pair_df.index.name = 'entity:pair_id'
 
-        if not dry:
+        if not dry_run:
             self.upload_entities('pair', pair_df)
         else:
             return pair_df


### PR DESCRIPTION
Currently, `WorkspaceManager.make_pairs` is a destructive action: it will immediately modify the workspace.

It's often useful to create a dataframe of pairs without actually updating the workspace's pair table. This PR adds that functionality.